### PR TITLE
fix(push): exclude held, deleted, and inactive-group messages from badge count

### DIFF
--- a/iznik-batch/app/Services/PushNotificationService.php
+++ b/iznik-batch/app/Services/PushNotificationService.php
@@ -138,6 +138,115 @@ class PushNotificationService
     }
 
     /**
+     * Compute the badge count for a ModTools user.
+     *
+     * Mirrors session.go's work total calculation:
+     * - Only ACTIVE groups (membership settings.active != 0 and settings.showmessages != 0)
+     * - Only unheld pending messages (heldby IS NULL)
+     * - Only spam collection messages (not spamtype in Pending)
+     * - Excludes deleted (mg.deleted = 0) and system messages (fromuser IS NOT NULL)
+     *
+     * This prevents phantom badges caused by held messages, deleted messages, or
+     * work from inactive groups inflating the count while the app shows nothing.
+     *
+     * Note: currently covers only pending + spam (2 of 14 session.go work categories).
+     * Omitted categories: pendingmembers, spammembers, pendingevents, pendingadmins,
+     * editreview, pendingvolunteering, stories, spammerpendingadd, spammerpendingremove,
+     * chatreview, newsletterstories, relatedmembers. Add those here as needed.
+     *
+     * See: Discourse #9547 — phantom badge count on Android/iOS ModTools.
+     */
+    public function getBadgeCount(int $userId): int
+    {
+        // Get all approved mod/owner memberships with settings to determine active/inactive.
+        $memberships = DB::select(
+            "SELECT groupid, settings FROM memberships
+             WHERE userid = ? AND role IN ('Owner', 'Moderator') AND collection = 'Approved'",
+            [$userId]
+        );
+
+        if (empty($memberships)) {
+            return 0;
+        }
+
+        // Mirror session.go: only count work from active groups in the badge total.
+        // Inactive groups' work appears as blue informational badges in the app — not in total.
+        $activeGroupIds = [];
+        foreach ($memberships as $m) {
+            if ($this->isActiveMod($m->settings)) {
+                $activeGroupIds[] = $m->groupid;
+            }
+        }
+
+        if (empty($activeGroupIds)) {
+            return 0;
+        }
+
+        $placeholders = implode(',', array_fill(0, count($activeGroupIds), '?'));
+
+        // Unheld pending messages in active groups.
+        $pendingParams = array_merge([$userId], $activeGroupIds);
+        $pending = DB::selectOne(
+            "SELECT COUNT(*) as cnt FROM messages_groups mg
+             INNER JOIN messages m ON m.id = mg.msgid
+             INNER JOIN memberships mem ON mem.groupid = mg.groupid AND mem.userid = ?
+             WHERE mem.role IN ('Owner', 'Moderator')
+             AND mem.collection = 'Approved'
+             AND mg.collection = 'Pending'
+             AND mg.groupid IN ({$placeholders})
+             AND mg.deleted = 0
+             AND m.fromuser IS NOT NULL
+             AND m.heldby IS NULL",
+            $pendingParams
+        );
+
+        // Spam collection messages in active groups.
+        $spamParams = array_merge([$userId], $activeGroupIds);
+        $spam = DB::selectOne(
+            "SELECT COUNT(*) as cnt FROM messages_groups mg
+             INNER JOIN messages m ON m.id = mg.msgid
+             INNER JOIN memberships mem ON mem.groupid = mg.groupid AND mem.userid = ?
+             WHERE mem.role IN ('Owner', 'Moderator')
+             AND mem.collection = 'Approved'
+             AND mg.collection = 'Spam'
+             AND mg.groupid IN ({$placeholders})
+             AND mg.deleted = 0
+             AND m.fromuser IS NOT NULL",
+            $spamParams
+        );
+
+        return ($pending->cnt ?? 0) + ($spam->cnt ?? 0);
+    }
+
+    /**
+     * Determine if a moderator is active for a group based on membership settings JSON.
+     *
+     * Mirrors session.go isActiveModForGroup: defaults to active unless explicitly
+     * set to false/0 via the 'active' or 'showmessages' setting.
+     */
+    private function isActiveMod(?string $settingsJson): bool
+    {
+        if (! $settingsJson) {
+            return true;
+        }
+
+        $settings = json_decode($settingsJson, true);
+        if (! is_array($settings)) {
+            return true;
+        }
+
+        if (array_key_exists('active', $settings)) {
+            return (bool) $settings['active'];
+        }
+
+        if (array_key_exists('showmessages', $settings)) {
+            return (bool) $settings['showmessages'];
+        }
+
+        return true;
+    }
+
+    /**
      * Build the ModTools notification payload.
      *
      * For ModTools, we send a simple "pending messages" notification.
@@ -145,29 +254,7 @@ class PushNotificationService
      */
     private function buildModToolsPayload(int $userId): ?array
     {
-        // Count pending messages across all groups this mod manages
-        $pending = DB::selectOne(
-            "SELECT COUNT(*) as cnt FROM messages_groups mg
-             INNER JOIN memberships m ON m.groupid = mg.groupid AND m.userid = ?
-             WHERE m.role IN ('Owner', 'Moderator')
-             AND mg.collection = 'Pending'",
-            [$userId]
-        );
-
-        // Count pending spam
-        $spam = DB::selectOne(
-            "SELECT COUNT(*) as cnt FROM messages_groups mg
-             INNER JOIN messages ON messages.id = mg.msgid
-             INNER JOIN memberships m ON m.groupid = mg.groupid AND m.userid = ?
-             WHERE m.role IN ('Owner', 'Moderator')
-             AND mg.collection = 'Pending'
-             AND messages.spamtype IS NOT NULL",
-            [$userId]
-        );
-
-        $pendingCount = $pending->cnt ?? 0;
-        $spamCount = $spam->cnt ?? 0;
-        $total = $pendingCount + $spamCount;
+        $total = $this->getBadgeCount($userId);
 
         if ($total === 0) {
             // Still send a zero-count to clear badge
@@ -188,10 +275,7 @@ class PushNotificationService
         }
 
         $title = "$total message" . ($total > 1 ? 's' : '') . " pending";
-        $message = $pendingCount . ' pending';
-        if ($spamCount > 0) {
-            $message .= ", $spamCount possible spam";
-        }
+        $message = "$total pending";
 
         return [
             'badge' => (string) $total,

--- a/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Group;
+use App\Models\Membership;
+use App\Models\Message;
+use App\Models\MessageGroup;
+use App\Services\PushNotificationService;
+use Tests\TestCase;
+
+/**
+ * Tests for PushNotificationService::getBadgeCount().
+ *
+ * Each test creates its own mod + group + membership and only queries that mod's count.
+ * Test isolation is provided by DatabaseTransactions in the base TestCase (each test
+ * rolls back all DB changes). No shared state between tests.
+ */
+class PushNotificationServiceTest extends TestCase
+{
+    protected PushNotificationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new PushNotificationService();
+    }
+
+    /**
+     * Held pending messages must NOT count towards the badge.
+     *
+     * Regression for Discourse #9547: mods reported a badge count of 1 but no
+     * actionable work. Root cause: held pending messages were counted in the
+     * badge but session.go's work total excludes heldby IS NOT NULL messages.
+     */
+    public function test_held_pending_messages_do_not_count_towards_badge(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $sender = $this->createTestUser();
+        $message = Message::create([
+            'fromuser' => $sender->id,
+            'type' => Message::TYPE_OFFER,
+            'subject' => 'OFFER: Test (Location)',
+            'textbody' => 'Test',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+            'heldby' => $mod->id,  // held — must not count
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_PENDING,
+            'arrival' => now(),
+            'deleted' => 0,
+        ]);
+
+        $count = $this->service->getBadgeCount($mod->id);
+
+        $this->assertEquals(0, $count, 'Held pending messages must not inflate badge count');
+    }
+
+    /**
+     * Unheld pending messages DO count towards the badge.
+     */
+    public function test_unheld_pending_messages_count_towards_badge(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $sender = $this->createTestUser();
+        $message = Message::create([
+            'fromuser' => $sender->id,
+            'type' => Message::TYPE_OFFER,
+            'subject' => 'OFFER: Test (Location)',
+            'textbody' => 'Test',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+            'heldby' => null,  // not held — must count
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_PENDING,
+            'arrival' => now(),
+            'deleted' => 0,
+        ]);
+
+        $count = $this->service->getBadgeCount($mod->id);
+
+        $this->assertEquals(1, $count, 'Unheld pending messages must count towards badge');
+    }
+
+    /**
+     * Spam collection messages count towards the badge.
+     *
+     * Session.go uses COLLECTION_SPAM, not spamtype in Pending.
+     */
+    public function test_spam_collection_messages_count_towards_badge(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $sender = $this->createTestUser();
+        $message = Message::create([
+            'fromuser' => $sender->id,
+            'type' => Message::TYPE_OFFER,
+            'subject' => 'OFFER: Spam (Location)',
+            'textbody' => 'Spam',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+            'heldby' => null,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_SPAM,
+            'arrival' => now(),
+            'deleted' => 0,
+        ]);
+
+        $count = $this->service->getBadgeCount($mod->id);
+
+        $this->assertEquals(1, $count, 'Spam collection messages must count towards badge');
+    }
+
+    /**
+     * Deleted pending messages must NOT count towards the badge.
+     */
+    public function test_deleted_pending_messages_do_not_count_towards_badge(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $sender = $this->createTestUser();
+        $message = Message::create([
+            'fromuser' => $sender->id,
+            'type' => Message::TYPE_OFFER,
+            'subject' => 'OFFER: Deleted (Location)',
+            'textbody' => 'Deleted',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+            'heldby' => null,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_PENDING,
+            'arrival' => now(),
+            'deleted' => 1,  // deleted — must not count
+        ]);
+
+        $count = $this->service->getBadgeCount($mod->id);
+
+        $this->assertEquals(0, $count, 'Deleted messages must not inflate badge count');
+    }
+
+    /**
+     * Messages with null fromuser must NOT count towards the badge.
+     */
+    public function test_null_fromuser_messages_do_not_count_towards_badge(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $message = Message::create([
+            'fromuser' => null,  // no sender — must not count
+            'type' => Message::TYPE_OFFER,
+            'subject' => 'OFFER: System (Location)',
+            'textbody' => 'System',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_PENDING,
+            'arrival' => now(),
+            'deleted' => 0,
+        ]);
+
+        $count = $this->service->getBadgeCount($mod->id);
+
+        $this->assertEquals(0, $count, 'Messages with null fromuser must not inflate badge count');
+    }
+
+    /**
+     * Pending messages in inactive groups must NOT count towards the badge.
+     *
+     * Session.go excludes inactive group work from `total` (it goes to pendingother/blue).
+     * A mod can set themselves inactive via membership settings.active=0.
+     */
+    public function test_inactive_group_pending_messages_do_not_count_towards_badge(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, [
+            'role' => Membership::ROLE_MODERATOR,
+            'settings' => ['active' => 0],  // inactive — must not count (Membership model has array cast)
+        ]);
+
+        $sender = $this->createTestUser();
+        $message = Message::create([
+            'fromuser' => $sender->id,
+            'type' => Message::TYPE_OFFER,
+            'subject' => 'OFFER: Test (Location)',
+            'textbody' => 'Test',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+            'heldby' => null,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_PENDING,
+            'arrival' => now(),
+            'deleted' => 0,
+        ]);
+
+        $count = $this->service->getBadgeCount($mod->id);
+
+        $this->assertEquals(0, $count, 'Inactive group pending messages must not inflate badge count');
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes phantom badge count in ModTools app — mods saw "1 thing to do" badge but no actionable work
- Root cause: push notification badge counted held pending messages, deleted messages, and work from inactive groups, while session.go's work total excludes all of these
- Extracted getBadgeCount() in PushNotificationService to mirror session.go's logic: only unheld pending (heldby IS NULL), only Spam collection for spam, only active groups, deleted=0, fromuser IS NOT NULL
- Added isActiveMod() helper to check membership settings.active / settings.showmessages (mirrors session.go isActiveModForGroup)
- Simplified notification message body from "N pending, M possible spam" to "N pending" (total only)

## Test plan
- Added PushNotificationServiceTest with 6 tests, all passing:
  - Held pending messages -> badge = 0
  - Unheld pending messages -> badge = 1
  - Spam collection messages -> badge = 1
  - Deleted messages -> badge = 0
  - Null fromuser messages -> badge = 0
  - Inactive group pending messages -> badge = 0

## Notes
- getBadgeCount() currently covers 2 of 14 session.go work categories (pending + spam). Remaining 12 (pendingmembers, chatreview, etc.) are documented in the method docblock as a known gap — pre-existing behaviour, not introduced by this PR.

Fixes Discourse topic #9547 post #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)