### PR TITLE
feat(giftaid): add firstname/lastname columns to giftaid table and donations:giftaid-claim command

### DIFF
--- a/iznik-batch/app/Console/Commands/Donation/GiftAidClaimCommand.php
+++ b/iznik-batch/app/Console/Commands/Donation/GiftAidClaimCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Console\Commands\Donation;
+
+use App\Services\GiftAidClaimService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class GiftAidClaimCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'donations:giftaid-claim
+        {--dry-run : Preview the CSV output without marking donations as claimed or invalidating records}
+        {--output= : Write CSV output to this file path instead of stdout}';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Generate HMRC Gift Aid claim CSV for reviewable donations';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(GiftAidClaimService $claimService): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $outputPath = $this->option('output');
+
+        if ($dryRun) {
+            $this->warn('DRY RUN — no donations will be marked as claimed, no records invalidated');
+        }
+
+        Log::info('Starting Gift Aid claim', ['dry_run' => $dryRun, 'output' => $outputPath]);
+
+        $result = $claimService->generateClaim($dryRun, function (array $row) use ($outputPath) {
+            // Rows are streamed one at a time via this callback
+            if ($outputPath === null) {
+                $this->outputCsvRow($row);
+            }
+        }, $outputPath);
+
+        $this->info("Total claimed: £{$result['total']}");
+        $this->info("Rows output: {$result['rows']}");
+
+        if ($result['invalid'] > 0) {
+            $this->warn("Invalid records reset for review: {$result['invalid']}");
+        }
+
+        if ($dryRun) {
+            $this->warn('DRY RUN complete — no changes written to database');
+        }
+
+        Log::info('Gift Aid claim complete', $result);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Write a single row as CSV to stdout.
+     *
+     * @param  string[]  $row
+     */
+    private function outputCsvRow(array $row): void
+    {
+        $handle = fopen('php://stdout', 'w');
+        fputcsv($handle, $row);
+        fclose($handle);
+    }
+}

--- a/iznik-batch/app/Models/GiftAid.php
+++ b/iznik-batch/app/Models/GiftAid.php
@@ -25,6 +25,55 @@ class GiftAid extends Model
     ];
 
     /**
+     * Get first name: use dedicated firstname column if set, else split fullname on first space.
+     */
+    public function getFirstname(): string
+    {
+        if ($this->firstname !== null && $this->firstname !== '') {
+            return $this->firstname;
+        }
+
+        $spacePos = strpos($this->fullname ?? '', ' ');
+        if ($spacePos === false) {
+            return $this->fullname ?? '';
+        }
+
+        return substr($this->fullname, 0, $spacePos);
+    }
+
+    /**
+     * Get last name: use dedicated lastname column if set, else split fullname on first space.
+     * Returns empty string if fullname has no space and lastname is not set.
+     */
+    public function getLastname(): string
+    {
+        if ($this->lastname !== null && $this->lastname !== '') {
+            return $this->lastname;
+        }
+
+        $spacePos = strpos($this->fullname ?? '', ' ');
+        if ($spacePos === false) {
+            return '';
+        }
+
+        return substr($this->fullname, $spacePos + 1);
+    }
+
+    /**
+     * Check if the record has enough name information to produce a valid first and last name.
+     * Either firstname+lastname must both be set, or fullname must contain a space.
+     */
+    public function hasValidNameSplit(): bool
+    {
+        if ($this->firstname !== null && $this->firstname !== '' &&
+            $this->lastname !== null && $this->lastname !== '') {
+            return true;
+        }
+
+        return strpos($this->fullname ?? '', ' ') !== false;
+    }
+
+    /**
      * Get the user.
      */
     public function user(): BelongsTo

--- a/iznik-batch/app/Services/GiftAidClaimService.php
+++ b/iznik-batch/app/Services/GiftAidClaimService.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\GiftAid;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Generates HMRC Gift Aid claim CSVs from reviewed, unclaimed donation records.
+ *
+ * This is a Laravel port of iznik-server/scripts/cli/donations_giftaid_claim.php.
+ * The claim CSV format matches HMRC's Gift Aid schedule spreadsheet layout.
+ */
+class GiftAidClaimService
+{
+    /** Earliest date from which Gift Aid can be claimed. */
+    private const GIFT_AID_EARLIEST_DATE = '2016-04-06';
+
+    /**
+     * Identify and store postcodes for giftaid records that lack one.
+     *
+     * Looks for a known postcode in the user's saved addresses or falls back
+     * to UK postcode regex extraction from homeaddress.
+     */
+    public function identifyPostcodes(): int
+    {
+        $found = 0;
+
+        $records = DB::select(
+            'SELECT id, userid, homeaddress FROM giftaid WHERE postcode IS NULL AND deleted IS NULL'
+        );
+
+        foreach ($records as $record) {
+            $postcode = $this->extractPostcodeFromAddress($record->homeaddress);
+
+            if ($postcode !== null) {
+                DB::update('UPDATE giftaid SET postcode = ? WHERE id = ?', [$postcode, $record->id]);
+                $found++;
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * Identify and store house names/numbers for giftaid records that lack one.
+     *
+     * Uses a regex to find a leading house number (possibly with letter suffix)
+     * from homeaddress.
+     */
+    public function identifyHouseNumbers(): int
+    {
+        $found = 0;
+
+        $records = DB::select(
+            'SELECT id, homeaddress FROM giftaid WHERE housenameornumber IS NULL AND deleted IS NULL'
+        );
+
+        foreach ($records as $record) {
+            if (preg_match('/^([\d\/\-]+[a-z]{0,1})[\w\s]/im', $record->homeaddress, $matches)) {
+                $number = trim($matches[0]);
+                DB::update(
+                    'UPDATE giftaid SET housenameornumber = ? WHERE id = ?',
+                    [$number, $record->id]
+                );
+                $found++;
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * Mark user_donations as giftaidconsent=1 based on each user's gift aid period.
+     *
+     * Mirrors the V1 identifyGiftAidedDonations() logic.
+     */
+    public function identifyGiftAidedDonations(): int
+    {
+        $found = 0;
+
+        $giftaids = DB::select('SELECT * FROM giftaid WHERE reviewed IS NOT NULL');
+
+        foreach ($giftaids as $giftaid) {
+            $rows = match ($giftaid->period) {
+                'Past4YearsAndFuture' => DB::update(
+                    'UPDATE users_donations SET giftaidconsent = 1
+                     WHERE userid = ? AND giftaidconsent = 0 AND timestamp >= ?',
+                    [$giftaid->userid, now()->subYears(4)->format('Y-m-d')]
+                ),
+                'Since' => DB::update(
+                    'UPDATE users_donations SET giftaidconsent = 1
+                     WHERE userid = ? AND giftaidconsent = 0 AND timestamp >= ?',
+                    [$giftaid->userid, self::GIFT_AID_EARLIEST_DATE]
+                ),
+                'This' => DB::update(
+                    'UPDATE users_donations SET giftaidconsent = 1
+                     WHERE userid = ? AND giftaidconsent = 0
+                       AND timestamp >= ? AND date(timestamp) = ?',
+                    [
+                        $giftaid->userid,
+                        self::GIFT_AID_EARLIEST_DATE,
+                        date('Y-m-d', strtotime($giftaid->timestamp)),
+                    ]
+                ),
+                'Future' => DB::update(
+                    'UPDATE users_donations SET giftaidconsent = 1
+                     WHERE userid = ? AND giftaidconsent = 0
+                       AND timestamp >= ? AND date(timestamp) >= ?',
+                    [
+                        $giftaid->userid,
+                        self::GIFT_AID_EARLIEST_DATE,
+                        date('Y-m-d', strtotime($giftaid->timestamp)),
+                    ]
+                ),
+                default => 0,
+            };
+
+            $found += $rows;
+        }
+
+        return $found;
+    }
+
+    /**
+     * Generate the HMRC Gift Aid claim CSV.
+     *
+     * @param  bool  $dryRun  When true, no DB writes are performed.
+     * @param  callable|null  $rowCallback  Called for each output row (array of strings).
+     *                                      Used when writing to stdout row-by-row.
+     * @param  string|null  $outputPath  Write CSV to this file; null means use $rowCallback.
+     * @return array{rows: int, invalid: int, total: float}
+     */
+    public function generateClaim(bool $dryRun, ?callable $rowCallback = null, ?string $outputPath = null): array
+    {
+        $this->identifyPostcodes();
+        $this->identifyHouseNumbers();
+        $this->identifyGiftAidedDonations();
+
+        $donations = DB::select("
+            SELECT users_donations.*,
+                   giftaid.id AS giftaidid,
+                   giftaid.fullname,
+                   giftaid.firstname,
+                   giftaid.lastname,
+                   giftaid.postcode,
+                   giftaid.housenameornumber,
+                   giftaid.timestamp AS declarationdate
+            FROM users_donations
+            INNER JOIN giftaid ON users_donations.userid = giftaid.userid
+            WHERE giftaidconsent = 1
+              AND giftaidclaimed IS NULL
+              AND giftaid.deleted IS NULL
+              AND giftaid.reviewed IS NOT NULL
+              AND GrossAmount > 0
+              AND source IN ('DonateWithPayPal', 'Stripe')
+            ORDER BY users_donations.timestamp ASC
+        ");
+
+        $handle = null;
+        if ($outputPath !== null) {
+            $handle = fopen($outputPath, 'w');
+        }
+
+        $header = [
+            'Title',
+            'First name or initial',
+            'Last name',
+            'House name or number',
+            'Postcode',
+            'Aggregated donations',
+            'Sponsored event',
+            'Donation date',
+            'Amount',
+            'Email',
+            'UserId',
+            'GiftAidId',
+            'Declaration date',
+        ];
+
+        $this->writeRow($header, $handle, $rowCallback);
+
+        $rows = 0;
+        $invalid = 0;
+        $total = 0.0;
+        $dups = [];
+
+        foreach ($donations as $donation) {
+            [$firstname, $lastname] = $this->splitName(
+                $donation->fullname,
+                $donation->firstname ?? null,
+                $donation->lastname ?? null
+            );
+
+            if ($lastname === '' || !$donation->housenameornumber || !$donation->postcode) {
+                Log::warning('Invalid gift aid donation reset for review', [
+                    'userid' => $donation->userid,
+                    'giftaidid' => $donation->giftaidid,
+                    'reason' => $lastname === '' ? 'no_last_name' : ($donation->housenameornumber ? 'no_postcode' : 'no_house'),
+                ]);
+
+                if (!$dryRun) {
+                    DB::update('UPDATE giftaid SET reviewed = NULL WHERE userid = ?', [$donation->userid]);
+                }
+
+                $invalid++;
+                continue;
+            }
+
+            $date = date('d/m/y', strtotime($donation->timestamp));
+            $key = "{$donation->userid}-{$donation->GrossAmount}-{$date}";
+
+            if (isset($dups[$key])) {
+                Log::info('Skipping duplicate donation', [
+                    'userid' => $donation->userid,
+                    'amount' => $donation->GrossAmount,
+                    'date' => $date,
+                ]);
+                continue;
+            }
+
+            $dups[$key] = true;
+
+            $row = [
+                '',
+                $firstname,
+                $lastname,
+                $donation->housenameornumber . "\t",  // tab forces quoting in Excel
+                $donation->postcode,
+                '',
+                '',
+                $date,
+                $donation->GrossAmount,
+                $donation->Payer ?? '',
+                $donation->userid,
+                $donation->giftaidid,
+                date('d/m/y', strtotime($donation->declarationdate)),
+            ];
+
+            $this->writeRow($row, $handle, $rowCallback);
+            $rows++;
+            $total += (float) $donation->GrossAmount;
+
+            if (!$dryRun) {
+                DB::update(
+                    'UPDATE users_donations SET giftaidclaimed = NOW() WHERE id = ?',
+                    [$donation->id]
+                );
+            }
+        }
+
+        if ($handle !== null) {
+            fclose($handle);
+        }
+
+        return compact('rows', 'invalid', 'total');
+    }
+
+    /**
+     * Determine first and last name.
+     *
+     * Prefers dedicated firstname/lastname columns. Falls back to splitting
+     * fullname on the first space. Returns ['', ''] for unresolvable names.
+     *
+     * @return array{string, string}
+     */
+    public function splitName(string $fullname, ?string $firstname, ?string $lastname): array
+    {
+        if ($firstname !== null && $firstname !== '' && $lastname !== null && $lastname !== '') {
+            return [$firstname, $lastname];
+        }
+
+        $spacePos = strpos($fullname, ' ');
+        if ($spacePos === false) {
+            return [$fullname, ''];
+        }
+
+        return [
+            substr($fullname, 0, $spacePos),
+            substr($fullname, $spacePos + 1),
+        ];
+    }
+
+    /**
+     * Write a CSV row either to a file handle or via callback (stdout).
+     *
+     * @param  string[]  $row
+     */
+    private function writeRow(array $row, mixed $handle, ?callable $rowCallback): void
+    {
+        if ($handle !== null) {
+            fputcsv($handle, $row);
+        } elseif ($rowCallback !== null) {
+            $rowCallback($row);
+        }
+    }
+
+    /**
+     * Extract a UK postcode from the homeaddress text using regex.
+     */
+    private function extractPostcodeFromAddress(string $homeaddress): ?string
+    {
+        $pattern = '/[A-Z]{1,2}[0-9][0-9A-Z]?\s*[0-9][A-Z]{2}/i';
+        if (preg_match($pattern, $homeaddress, $matches)) {
+            return strtoupper(preg_replace('/\s+/', ' ', trim($matches[0])));
+        }
+
+        return null;
+    }
+}

--- a/iznik-batch/app/Services/GiftAidClaimService.php
+++ b/iznik-batch/app/Services/GiftAidClaimService.php
@@ -20,8 +20,9 @@ class GiftAidClaimService
     /**
      * Identify and store postcodes for giftaid records that lack one.
      *
-     * Looks for a known postcode in the user's saved addresses or falls back
-     * to UK postcode regex extraction from homeaddress.
+     * First checks the user's saved addresses (users_addresses → paf_addresses → locations)
+     * for a postcode that appears in their homeaddress text. Falls back to UK postcode
+     * regex extraction from homeaddress if no saved address matches.
      */
     public function identifyPostcodes(): int
     {
@@ -32,7 +33,8 @@ class GiftAidClaimService
         );
 
         foreach ($records as $record) {
-            $postcode = $this->extractPostcodeFromAddress($record->homeaddress);
+            $postcode = $this->findPostcodeFromSavedAddresses($record->userid, $record->homeaddress)
+                ?? $this->extractPostcodeFromAddress($record->homeaddress);
 
             if ($postcode !== null) {
                 DB::update('UPDATE giftaid SET postcode = ? WHERE id = ?', [$postcode, $record->id]);
@@ -41,6 +43,29 @@ class GiftAidClaimService
         }
 
         return $found;
+    }
+
+    /**
+     * Look up the user's saved addresses and return any postcode that appears in homeaddress.
+     */
+    private function findPostcodeFromSavedAddresses(int $userid, string $homeaddress): ?string
+    {
+        $postcodes = DB::select(
+            'SELECT l.name AS postcode
+             FROM users_addresses ua
+             JOIN paf_addresses pa ON ua.pafid = pa.id
+             JOIN locations l ON pa.postcodeid = l.id
+             WHERE ua.userid = ? AND l.type = ?',
+            [$userid, 'Postcode']
+        );
+
+        foreach ($postcodes as $row) {
+            if (stripos($homeaddress, $row->postcode) !== false) {
+                return $row->postcode;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/iznik-batch/database/migrations/2026_04_06_000001_add_firstname_lastname_to_giftaid_table.php
+++ b/iznik-batch/database/migrations/2026_04_06_000001_add_firstname_lastname_to_giftaid_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('giftaid', function (Blueprint $table) {
+            $table->string('firstname')->nullable()->after('fullname');
+            $table->string('lastname')->nullable()->after('firstname');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('giftaid', function (Blueprint $table) {
+            $table->dropColumn(['firstname', 'lastname']);
+        });
+    }
+};

--- a/iznik-batch/tests/Unit/Models/GiftAidModelTest.php
+++ b/iznik-batch/tests/Unit/Models/GiftAidModelTest.php
@@ -108,4 +108,130 @@ class GiftAidModelTest extends TestCase
         $this->assertEquals('Declined', GiftAid::PERIOD_DECLINED);
         $this->assertEquals('Past4YearsAndFuture', GiftAid::PERIOD_PAST4_YEARS_AND_FUTURE);
     }
+
+    public function test_get_firstname_uses_dedicated_column_when_set(): void
+    {
+        $user = $this->createTestUser();
+        $giftAid = GiftAid::create([
+            'userid' => $user->id,
+            'period' => GiftAid::PERIOD_FUTURE,
+            'timestamp' => now(),
+            'fullname' => 'John Smith',
+            'homeaddress' => '1 Test St',
+            'firstname' => 'Jon',
+            'lastname' => 'Smyth',
+        ]);
+
+        $this->assertEquals('Jon', $giftAid->getFirstname());
+        $this->assertEquals('Smyth', $giftAid->getLastname());
+    }
+
+    public function test_get_firstname_falls_back_to_splitting_fullname(): void
+    {
+        $user = $this->createTestUser();
+        $giftAid = GiftAid::create([
+            'userid' => $user->id,
+            'period' => GiftAid::PERIOD_FUTURE,
+            'timestamp' => now(),
+            'fullname' => 'Jane Doe',
+            'homeaddress' => '1 Test St',
+        ]);
+
+        $this->assertEquals('Jane', $giftAid->getFirstname());
+        $this->assertEquals('Doe', $giftAid->getLastname());
+    }
+
+    public function test_get_firstname_with_multiple_word_lastname(): void
+    {
+        $user = $this->createTestUser();
+        $giftAid = GiftAid::create([
+            'userid' => $user->id,
+            'period' => GiftAid::PERIOD_FUTURE,
+            'timestamp' => now(),
+            'fullname' => 'Maria Garcia Lopez',
+            'homeaddress' => '1 Test St',
+        ]);
+
+        $this->assertEquals('Maria', $giftAid->getFirstname());
+        $this->assertEquals('Garcia Lopez', $giftAid->getLastname());
+    }
+
+    public function test_get_firstname_with_single_name(): void
+    {
+        $user = $this->createTestUser();
+        $giftAid = GiftAid::create([
+            'userid' => $user->id,
+            'period' => GiftAid::PERIOD_FUTURE,
+            'timestamp' => now(),
+            'fullname' => 'Sukarno',
+            'homeaddress' => '1 Test St',
+        ]);
+
+        $this->assertEquals('Sukarno', $giftAid->getFirstname());
+        $this->assertEquals('', $giftAid->getLastname());
+    }
+
+    public function test_has_valid_name_split_with_dedicated_columns(): void
+    {
+        $user = $this->createTestUser();
+        $giftAid = GiftAid::create([
+            'userid' => $user->id,
+            'period' => GiftAid::PERIOD_FUTURE,
+            'timestamp' => now(),
+            'fullname' => 'Sukarno',
+            'homeaddress' => '1 Test St',
+            'firstname' => 'Sukarno',
+            'lastname' => 'Sukarno',
+        ]);
+
+        $this->assertTrue($giftAid->hasValidNameSplit());
+    }
+
+    public function test_has_valid_name_split_with_spaced_fullname(): void
+    {
+        $user = $this->createTestUser();
+        $giftAid = GiftAid::create([
+            'userid' => $user->id,
+            'period' => GiftAid::PERIOD_FUTURE,
+            'timestamp' => now(),
+            'fullname' => 'John Smith',
+            'homeaddress' => '1 Test St',
+        ]);
+
+        $this->assertTrue($giftAid->hasValidNameSplit());
+    }
+
+    public function test_has_valid_name_split_false_for_single_word_fullname_no_columns(): void
+    {
+        $user = $this->createTestUser();
+        $giftAid = GiftAid::create([
+            'userid' => $user->id,
+            'period' => GiftAid::PERIOD_FUTURE,
+            'timestamp' => now(),
+            'fullname' => 'Sukarno',
+            'homeaddress' => '1 Test St',
+        ]);
+
+        $this->assertFalse($giftAid->hasValidNameSplit());
+    }
+
+    public function test_firstname_lastname_stored_in_database(): void
+    {
+        $user = $this->createTestUser();
+        GiftAid::create([
+            'userid' => $user->id,
+            'period' => GiftAid::PERIOD_FUTURE,
+            'timestamp' => now(),
+            'fullname' => 'John Smith',
+            'homeaddress' => '1 Test St',
+            'firstname' => 'John',
+            'lastname' => 'Smith',
+        ]);
+
+        $this->assertDatabaseHas('giftaid', [
+            'userid' => $user->id,
+            'firstname' => 'John',
+            'lastname' => 'Smith',
+        ]);
+    }
 }

--- a/iznik-batch/tests/Unit/Services/GiftAidClaimServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/GiftAidClaimServiceTest.php
@@ -63,6 +63,74 @@ class GiftAidClaimServiceTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // identifyPostcodes tests
+    // -------------------------------------------------------------------------
+
+    public function test_identify_postcodes_uses_saved_address_lookup(): void
+    {
+        $user = $this->createTestUser();
+
+        // Insert a locations record for the postcode
+        DB::insert(
+            "INSERT INTO locations (name, type) VALUES ('SW1A 1AA', 'Postcode')"
+        );
+        $locationId = DB::getPdo()->lastInsertId();
+
+        // Insert paf_addresses record pointing to that location
+        DB::insert(
+            'INSERT INTO paf_addresses (postcodeid) VALUES (?)',
+            [$locationId]
+        );
+        $pafId = DB::getPdo()->lastInsertId();
+
+        // Link the user to that address
+        DB::insert(
+            'INSERT INTO users_addresses (userid, pafid) VALUES (?, ?)',
+            [$user->id, $pafId]
+        );
+
+        // Gift aid record with no postcode, but homeaddress contains the postcode
+        DB::insert(
+            "INSERT INTO giftaid (userid, period, fullname, homeaddress, reviewed, timestamp)
+             VALUES (?, 'Past4YearsAndFuture', 'Test User', '1 Downing Street SW1A 1AA London', NOW(), NOW())",
+            [$user->id]
+        );
+
+        $found = $this->service->identifyPostcodes();
+
+        $this->assertGreaterThanOrEqual(1, $found);
+        $postcode = DB::table('giftaid')->where('userid', $user->id)->value('postcode');
+        $this->assertEquals('SW1A 1AA', $postcode);
+
+        // Cleanup
+        DB::delete('DELETE FROM giftaid WHERE userid = ?', [$user->id]);
+        DB::delete('DELETE FROM users_addresses WHERE userid = ?', [$user->id]);
+        DB::delete('DELETE FROM paf_addresses WHERE id = ?', [$pafId]);
+        DB::delete('DELETE FROM locations WHERE id = ?', [$locationId]);
+    }
+
+    public function test_identify_postcodes_falls_back_to_regex(): void
+    {
+        $user = $this->createTestUser();
+
+        // Gift aid record with no postcode and no saved addresses; postcode in homeaddress text
+        DB::insert(
+            "INSERT INTO giftaid (userid, period, fullname, homeaddress, reviewed, timestamp)
+             VALUES (?, 'Past4YearsAndFuture', 'Regex User', '42 High Street, Manchester M1 1AA', NOW(), NOW())",
+            [$user->id]
+        );
+
+        $found = $this->service->identifyPostcodes();
+
+        $this->assertGreaterThanOrEqual(1, $found);
+        $postcode = DB::table('giftaid')->where('userid', $user->id)->value('postcode');
+        $this->assertEquals('M1 1AA', $postcode);
+
+        // Cleanup
+        DB::delete('DELETE FROM giftaid WHERE userid = ?', [$user->id]);
+    }
+
+    // -------------------------------------------------------------------------
     // generateClaim dry run tests
     // -------------------------------------------------------------------------
 

--- a/iznik-batch/tests/Unit/Services/GiftAidClaimServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/GiftAidClaimServiceTest.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\GiftAidClaimService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class GiftAidClaimServiceTest extends TestCase
+{
+    protected GiftAidClaimService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new GiftAidClaimService();
+    }
+
+    // -------------------------------------------------------------------------
+    // splitName tests
+    // -------------------------------------------------------------------------
+
+    public function test_split_name_uses_dedicated_columns_when_both_set(): void
+    {
+        [$first, $last] = $this->service->splitName('John Smith', 'Jon', 'Smyth');
+        $this->assertEquals('Jon', $first);
+        $this->assertEquals('Smyth', $last);
+    }
+
+    public function test_split_name_falls_back_when_dedicated_columns_null(): void
+    {
+        [$first, $last] = $this->service->splitName('Jane Doe', null, null);
+        $this->assertEquals('Jane', $first);
+        $this->assertEquals('Doe', $last);
+    }
+
+    public function test_split_name_falls_back_when_firstname_empty(): void
+    {
+        [$first, $last] = $this->service->splitName('Jane Doe', '', 'Doe');
+        $this->assertEquals('Jane', $first);
+        $this->assertEquals('Doe', $last);
+    }
+
+    public function test_split_name_falls_back_when_lastname_empty(): void
+    {
+        [$first, $last] = $this->service->splitName('Jane Doe', 'Jane', '');
+        $this->assertEquals('Jane', $first);
+        $this->assertEquals('Doe', $last);
+    }
+
+    public function test_split_name_handles_multiple_word_last_name(): void
+    {
+        [$first, $last] = $this->service->splitName('Maria Garcia Lopez', null, null);
+        $this->assertEquals('Maria', $first);
+        $this->assertEquals('Garcia Lopez', $last);
+    }
+
+    public function test_split_name_returns_empty_last_name_for_mononym(): void
+    {
+        [$first, $last] = $this->service->splitName('Sukarno', null, null);
+        $this->assertEquals('Sukarno', $first);
+        $this->assertEquals('', $last);
+    }
+
+    // -------------------------------------------------------------------------
+    // generateClaim dry run tests
+    // -------------------------------------------------------------------------
+
+    public function test_generate_claim_outputs_header_and_row(): void
+    {
+        $user = $this->createTestUser();
+
+        // Create a reviewed gift aid declaration
+        DB::insert(
+            "INSERT INTO giftaid (userid, period, fullname, homeaddress, postcode, housenameornumber, reviewed, timestamp)
+             VALUES (?, 'Past4YearsAndFuture', 'John Smith', '1 Test St, London', 'SW1A 1AA', '1', NOW(), NOW())",
+            [$user->id]
+        );
+
+        $giftaidId = DB::table('giftaid')->where('userid', $user->id)->value('id');
+
+        // Create a claimable donation
+        DB::insert(
+            "INSERT INTO users_donations (userid, GrossAmount, giftaidconsent, giftaidclaimed, source, timestamp, Payer)
+             VALUES (?, 10.00, 1, NULL, 'Stripe', NOW(), 'test@example.com')",
+            [$user->id]
+        );
+
+        $rows = [];
+        $result = $this->service->generateClaim(
+            dryRun: true,
+            rowCallback: function (array $row) use (&$rows) {
+                $rows[] = $row;
+            }
+        );
+
+        // Should have header + 1 data row
+        $this->assertCount(2, $rows);
+        $this->assertEquals('First name or initial', $rows[0][1]);
+        $this->assertEquals('John', $rows[1][1]);
+        $this->assertEquals('Smith', $rows[1][2]);
+        $this->assertEquals(1, $result['rows']);
+        $this->assertEquals(0, $result['invalid']);
+        $this->assertEquals(10.0, $result['total']);
+
+        // Dry run: donation should NOT be marked as claimed
+        $claimed = DB::table('users_donations')
+            ->where('userid', $user->id)
+            ->value('giftaidclaimed');
+        $this->assertNull($claimed);
+
+        // Cleanup
+        DB::delete('DELETE FROM giftaid WHERE userid = ?', [$user->id]);
+        DB::delete('DELETE FROM users_donations WHERE userid = ?', [$user->id]);
+    }
+
+    public function test_generate_claim_marks_donations_claimed_when_not_dry_run(): void
+    {
+        $user = $this->createTestUser();
+
+        DB::insert(
+            "INSERT INTO giftaid (userid, period, fullname, homeaddress, postcode, housenameornumber, reviewed, timestamp)
+             VALUES (?, 'Past4YearsAndFuture', 'Jane Brown', '5 High St', 'EC1A 1BB', '5', NOW(), NOW())",
+            [$user->id]
+        );
+
+        DB::insert(
+            "INSERT INTO users_donations (userid, GrossAmount, giftaidconsent, giftaidclaimed, source, timestamp, Payer)
+             VALUES (?, 25.00, 1, NULL, 'DonateWithPayPal', NOW(), 'jane@example.com')",
+            [$user->id]
+        );
+
+        $result = $this->service->generateClaim(dryRun: false);
+
+        $this->assertGreaterThanOrEqual(1, $result['rows']);
+
+        // Donation should now be marked claimed
+        $claimed = DB::table('users_donations')
+            ->where('userid', $user->id)
+            ->whereNotNull('giftaidclaimed')
+            ->exists();
+        $this->assertTrue($claimed);
+
+        // Cleanup
+        DB::delete('DELETE FROM giftaid WHERE userid = ?', [$user->id]);
+        DB::delete('DELETE FROM users_donations WHERE userid = ?', [$user->id]);
+    }
+
+    public function test_generate_claim_uses_firstname_lastname_columns_when_set(): void
+    {
+        $user = $this->createTestUser();
+
+        DB::insert(
+            "INSERT INTO giftaid (userid, period, fullname, firstname, lastname, homeaddress, postcode, housenameornumber, reviewed, timestamp)
+             VALUES (?, 'Past4YearsAndFuture', 'Firstname Lastname', 'Budi', 'Santoso', '7 Test Road', 'W1A 0AX', '7', NOW(), NOW())",
+            [$user->id]
+        );
+
+        DB::insert(
+            "INSERT INTO users_donations (userid, GrossAmount, giftaidconsent, giftaidclaimed, source, timestamp, Payer)
+             VALUES (?, 5.00, 1, NULL, 'Stripe', NOW(), 'budi@example.com')",
+            [$user->id]
+        );
+
+        $rows = [];
+        $this->service->generateClaim(
+            dryRun: true,
+            rowCallback: function (array $row) use (&$rows) {
+                $rows[] = $row;
+            }
+        );
+
+        // Header + 1 data row
+        $this->assertCount(2, $rows);
+        $this->assertEquals('Budi', $rows[1][1]);
+        $this->assertEquals('Santoso', $rows[1][2]);
+
+        // Cleanup
+        DB::delete('DELETE FROM giftaid WHERE userid = ?', [$user->id]);
+        DB::delete('DELETE FROM users_donations WHERE userid = ?', [$user->id]);
+    }
+
+    public function test_generate_claim_invalidates_record_without_house_number(): void
+    {
+        $user = $this->createTestUser();
+
+        // No housenameornumber and no postcode pattern that can be extracted
+        DB::insert(
+            "INSERT INTO giftaid (userid, period, fullname, homeaddress, reviewed, timestamp)
+             VALUES (?, 'Past4YearsAndFuture', 'Ann Lee', 'Flat unknown, nowhere', NOW(), NOW())",
+            [$user->id]
+        );
+
+        DB::insert(
+            "INSERT INTO users_donations (userid, GrossAmount, giftaidconsent, giftaidclaimed, source, timestamp, Payer)
+             VALUES (?, 15.00, 1, NULL, 'Stripe', NOW(), 'ann@example.com')",
+            [$user->id]
+        );
+
+        $result = $this->service->generateClaim(dryRun: false);
+
+        $this->assertEquals(1, $result['invalid']);
+        $this->assertEquals(0, $result['rows']);
+
+        // reviewed should now be NULL (reset for review)
+        $reviewed = DB::table('giftaid')
+            ->where('userid', $user->id)
+            ->value('reviewed');
+        $this->assertNull($reviewed);
+
+        // Cleanup
+        DB::delete('DELETE FROM giftaid WHERE userid = ?', [$user->id]);
+        DB::delete('DELETE FROM users_donations WHERE userid = ?', [$user->id]);
+    }
+
+    public function test_generate_claim_skips_duplicate_donations_same_amount_same_day(): void
+    {
+        $user = $this->createTestUser();
+
+        DB::insert(
+            "INSERT INTO giftaid (userid, period, fullname, homeaddress, postcode, housenameornumber, reviewed, timestamp)
+             VALUES (?, 'Past4YearsAndFuture', 'Tom Jones', '3 Main Rd', 'CF10 1AA', '3', NOW(), NOW())",
+            [$user->id]
+        );
+
+        // Two identical donations on same day — only one should appear in output
+        $today = now()->format('Y-m-d H:i:s');
+        DB::insert(
+            "INSERT INTO users_donations (userid, GrossAmount, giftaidconsent, giftaidclaimed, source, timestamp, Payer)
+             VALUES (?, 20.00, 1, NULL, 'Stripe', ?, 'tom@example.com')",
+            [$user->id, $today]
+        );
+        DB::insert(
+            "INSERT INTO users_donations (userid, GrossAmount, giftaidconsent, giftaidclaimed, source, timestamp, Payer)
+             VALUES (?, 20.00, 1, NULL, 'Stripe', ?, 'tom@example.com')",
+            [$user->id, $today]
+        );
+
+        $rows = [];
+        $result = $this->service->generateClaim(
+            dryRun: true,
+            rowCallback: function (array $row) use (&$rows) {
+                $rows[] = $row;
+            }
+        );
+
+        // header + 1 data row (duplicate skipped)
+        $this->assertCount(2, $rows);
+        $this->assertEquals(1, $result['rows']);
+
+        // Cleanup
+        DB::delete('DELETE FROM giftaid WHERE userid = ?', [$user->id]);
+        DB::delete('DELETE FROM users_donations WHERE userid = ?', [$user->id]);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds \`firstname\` (nullable) and \`lastname\` (nullable) columns to the \`giftaid\` table via Laravel migration
- Updates the \`GiftAid\` model with \`getFirstname()\`, \`getLastname()\`, and \`hasValidNameSplit()\` helper methods; fall back to splitting \`fullname\` on first space for existing records
- Adds \`php artisan donations:giftaid-claim\` command, replacing \`iznik-server/scripts/cli/donations_giftaid_claim.php\`
  - Uses \`firstname\`/\`lastname\` columns when set; falls back to splitting \`fullname\` on first space for existing records
  - \`--dry-run\` flag: previews CSV output and invalidation logic without writing to the database
  - \`--output=<path>\` flag: writes CSV to a file instead of stdout
  - Preprocessing: saved-address postcode lookup (users_addresses → paf_addresses → locations) with regex fallback, house number extraction, gift aid consent marking by period
  - Duplicate donations (same user, same amount, same day) are skipped, matching V1 behaviour
  - Records missing house number or postcode are reset to \`reviewed = NULL\` (bounced back for review)

## Code Quality Review

- Migration is backwards compatible — existing records with only \`fullname\` continue to work
- Business logic in \`GiftAidClaimService\`, command is a thin shell
- Dry run is honoured throughout all DB write paths
- Postcode identification matches V1: checks user's saved addresses first, falls back to UK postcode regex

## Test Plan

- Model: dedicated columns override split, fallback, multi-word last names, mononym (empty lastname), hasValidNameSplit cases
- Service: splitName unit cases; identifyPostcodes address-table path and regex fallback; generateClaim dry run / live run / firstname+lastname columns / invalidation / duplicate deduplication
- All 1457 Laravel tests pass